### PR TITLE
use node['root_group'] for greater compatibility

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,6 +2,6 @@ template "/etc/environment" do
   source "environment.erb"
   mode 0664
   owner "root"
-  group "root"
+  group node['root_group']
   variables({ :environment => node['etc_environment'] })
 end if node['etc_environment']


### PR DESCRIPTION
some distros do not have a 'root' group