### PR TITLE
improve structured data handling

### DIFF
--- a/templates/default/environment.erb
+++ b/templates/default/environment.erb
@@ -1,3 +1,3 @@
 <% @environment.each do |k, v| %>
-<%= (v.is_a?(Hash) || v.is_a?(Array)) ? "#{k}_BASE64=#{Base64.strict_encode64(v.to_json)}" : "#{k}=#{v.to_json}" %>
+<%= (v.kind_of?(Hash) || v.kind_of?(Array)) ? "#{k}_BASE64=#{Base64.strict_encode64(v.to_json)}" : "#{k}=#{v}" %>
 <% end %>


### PR DESCRIPTION
This PR resolves 2 issues:
- prevents JSON attributes from being double-escaped (now that structured data is being Base64 encoded, there should not be a need to call `.to_json` on other types of data)
- ensure that instances of subclasses of `Hash` and `Array` are Base64 encoded, such as  `Chef::Node::ImmutableArray`